### PR TITLE
Fix x32 build

### DIFF
--- a/src/clock_getres_template.c
+++ b/src/clock_getres_template.c
@@ -90,8 +90,8 @@ static void clock_getres_verify(struct ctx *ctx)
 			error(EXIT_FAILURE, 0,
 			      "clock resolution reported by kernel changed: "
 			      "from [%ld, %ld] to [%ld, %ld]",
-			      sanity.tv_sec, sanity.tv_nsec,
-			      kres.tv_sec, kres.tv_nsec);
+			      (long int)sanity.tv_sec, (long int)sanity.tv_nsec,
+			      (long int)kres.tv_sec, (long int)kres.tv_nsec);
 		}
 
 		if (!vdso_has_clock_getres())
@@ -102,8 +102,8 @@ static void clock_getres_verify(struct ctx *ctx)
 			log_failure(ctx, "clock resolutions differ:\n"
 				    "\t[%ld, %ld] (kernel)\n"
 				    "\t[%ld, %ld] (vDSO)\n",
-				    kres.tv_sec, kres.tv_nsec,
-				    vres.tv_sec, vres.tv_nsec);
+				    (long int)kres.tv_sec, (long int)kres.tv_nsec,
+				    (long int)vres.tv_sec, (long int)vres.tv_nsec);
 		}
 	}
 

--- a/src/clock_gettime_template.c
+++ b/src/clock_gettime_template.c
@@ -105,7 +105,7 @@ static void clock_gettime_verify(struct ctx *ctx)
 			log_failure(ctx, "timestamp obtained from libc/vDSO "
 				    "not normalized:\n"
 				    "\t[%ld, %ld]\n",
-				    now.tv_sec, now.tv_nsec);
+				    (long int)now.tv_sec, (long int)now.tv_nsec);
 		}
 
 		if (!timespecs_ordered(&prev, &now)) {
@@ -114,8 +114,8 @@ static void clock_gettime_verify(struct ctx *ctx)
 				    "previously obtained from kernel:\n"
 				    "\t[%ld, %ld] (kernel)\n"
 				    "\t[%ld, %ld] (vDSO)\n",
-				    prev.tv_sec, prev.tv_nsec,
-				    now.tv_sec, now.tv_nsec);
+				    (long int)prev.tv_sec, (long int)prev.tv_nsec,
+				    (long int)now.tv_sec, (long int)now.tv_nsec);
 		}
 
 	skip_vdso:
@@ -127,7 +127,7 @@ static void clock_gettime_verify(struct ctx *ctx)
 			log_failure(ctx, "timestamp obtained from kernel "
 				    "not normalized:\n"
 				    "\t[%ld, %ld]\n",
-				    now.tv_sec, now.tv_nsec);
+				    (long int)now.tv_sec, (long int)now.tv_nsec);
 		}
 
 		if (!timespecs_ordered(&prev, &now)) {
@@ -136,8 +136,8 @@ static void clock_gettime_verify(struct ctx *ctx)
 				    "previously obtained from libc/vDSO:\n"
 				    "\t[%ld, %ld] (vDSO)\n"
 				    "\t[%ld, %ld] (kernel)\n",
-				    prev.tv_sec, prev.tv_nsec,
-				    now.tv_sec, now.tv_nsec);
+				    (long int)prev.tv_sec, (long int)prev.tv_nsec,
+				    (long int)now.tv_sec, (long int)now.tv_nsec);
 		}
 
 	}

--- a/src/gettimeofday.c
+++ b/src/gettimeofday.c
@@ -108,7 +108,7 @@ static void gettimeofday_verify(struct ctx *ctx)
 			log_failure(ctx, "timestamp obtained from libc/vDSO "
 				    "not normalized:\n"
 				    "\t[%ld, %ld]\n",
-				    now.tv_sec, now.tv_usec);
+				    (long int)now.tv_sec, (long int)now.tv_usec);
 		}
 
 		if (!timevals_ordered(&prev, &now)) {
@@ -117,8 +117,8 @@ static void gettimeofday_verify(struct ctx *ctx)
 				    "previously obtained from kernel:\n"
 				    "\t[%ld, %ld] (kernel)\n"
 				    "\t[%ld, %ld] (vDSO)\n",
-				    prev.tv_sec, prev.tv_usec,
-				    now.tv_sec, now.tv_usec);
+				    (long int)prev.tv_sec, (long int)prev.tv_usec,
+				    (long int)now.tv_sec, (long int)now.tv_usec);
 		}
 
 	skip_vdso:
@@ -130,7 +130,7 @@ static void gettimeofday_verify(struct ctx *ctx)
 			log_failure(ctx, "timestamp obtained from kernel "
 				    "not normalized:\n"
 				    "\t[%ld, %ld]\n",
-				    now.tv_sec, now.tv_usec);
+				    (long int)now.tv_sec, (long int)now.tv_usec);
 		}
 
 		if (!timevals_ordered(&prev, &now)) {
@@ -139,8 +139,8 @@ static void gettimeofday_verify(struct ctx *ctx)
 				    "previously obtained from libc/vDSO:\n"
 				    "\t[%ld, %ld] (vDSO)\n"
 				    "\t[%ld, %ld] (kernel)\n",
-				    prev.tv_sec, prev.tv_usec,
-				    now.tv_sec, now.tv_usec);
+				    (long int)prev.tv_sec, (long int)prev.tv_usec,
+				    (long int)now.tv_sec, (long int)now.tv_usec);
 		}
 
 	}


### PR DESCRIPTION
This patch fixes the build on x32 due some usage type in printf:

vdsotest-git/src/clock-monotonic.c:5:0:
../vdsotest-git/src/clock_getres_template.c: In function ‘clock_getres_verify’:
../vdsotest-git/src/clock_getres_template.c:94:10: error: format ‘%ld’ expects iargument of type ‘long int’, but argument 4 has type ‘__time_t’ [-Werror=format=]
          (long int)kres.tv_sec, (long int)kres.tv_nsec);

Straightforward is just cast them to 'long int'.