### PR TITLE
Add support for more clock_id types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ libtool
 stamp-h1
 vdsotest
 vdsotest-all
+vdsotest-bench

--- a/Makefile.am
+++ b/Makefile.am
@@ -21,6 +21,9 @@ bin_PROGRAMS = vdsotest
 vdsotest_SOURCES = \
 	src/clock-monotonic.c \
 	src/clock-monotonic-coarse.c \
+	src/clock-monotonic-raw.c \
+	src/clock-tai.c \
+	src/clock-boottime.c \
 	src/clock-realtime.c \
 	src/clock-realtime-coarse.c \
 	src/compiler.h \

--- a/Makefile.am
+++ b/Makefile.am
@@ -36,7 +36,7 @@ vdsotest_SOURCES = \
 
 vdsotest_LDADD = -lrt -ldl
 
-bin_SCRIPTS = vdsotest-all
+bin_SCRIPTS = vdsotest-all vdsotest-bench
 
 CLEANFILES += $(bin_SCRIPTS)
 
@@ -46,7 +46,12 @@ vdsotest-all: src/vdsotest-all.in Makefile
 	$(do_subst) < $(srcdir)/src/vdsotest-all.in > vdsotest-all
 	chmod +x vdsotest-all
 
+vdsotest-bench: src/vdsotest-bench.in Makefile
+	$(do_subst) < $(srcdir)/src/vdsotest-bench.in > vdsotest-bench
+	chmod +x vdsotest-bench
+
 EXTRA_DIST += \
 	src/clock_getres_template.c \
 	src/clock_gettime_template.c \
-	src/vdsotest-all.in
+	src/vdsotest-all.in \
+	src/vdsotest-bench.in

--- a/src/clock-boottime.c
+++ b/src/clock-boottime.c
@@ -1,0 +1,5 @@
+#define CLOCK_ID CLOCK_BOOTTIME
+#define TS_SFX "boottime"
+
+#include "clock_gettime_template.c"
+#include "clock_getres_template.c"

--- a/src/clock-monotonic-raw.c
+++ b/src/clock-monotonic-raw.c
@@ -1,0 +1,5 @@
+#define CLOCK_ID CLOCK_MONOTONIC_RAW
+#define TS_SFX "monotonic-raw"
+
+#include "clock_gettime_template.c"
+#include "clock_getres_template.c"

--- a/src/clock-tai.c
+++ b/src/clock-tai.c
@@ -1,0 +1,9 @@
+#ifdef CLOCK_TAI
+#define CLOCK_ID CLOCK_TAI
+#else
+#define CLOCK_ID 11
+#endif
+#define TS_SFX "tai"
+
+#include "clock_gettime_template.c"
+#include "clock_getres_template.c"

--- a/src/vdsotest-bench.in
+++ b/src/vdsotest-bench.in
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+: ${vdsotest:=@vdsotest@}
+
+opts="$@"
+
+for api in $($vdsotest list-apis)
+do
+    $vdsotest $opts $api bench
+done


### PR DESCRIPTION
This patch adds support to the test-suite for the following clock_id
types:
 - CLOCK_BOOTTIME
 - CLOCK_MONOTONIC_RAW
 - CLOCK_TAI

for both clock_gettime and clock_getres.

This patch adds as well vdsotest-bench, similar to vdsotest-all but
executes only the benchmarks.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@linaro.org>