### PR TITLE
Make it work for MIPS

### DIFF
--- a/src/clock_getres_template.c
+++ b/src/clock_getres_template.c
@@ -269,7 +269,7 @@ static const struct child_params vdso_clock_getres_abi_params[] = {
 		.expected_ret = -1,
 		.expected_errno = EFAULT,
 		.signal_set = {
-			.mask = SIGNO_TO_BIT(SIGSEGV),
+			.mask = SIGNO_TO_BIT(SIGSEGV) | SIGNO_TO_BIT(SIGBUS),
 		},
 	},
 	{

--- a/src/clock_gettime_template.c
+++ b/src/clock_gettime_template.c
@@ -303,7 +303,7 @@ static const struct child_params vdso_clock_gettime_abi_params[] = {
 		.expected_ret = -1,
 		.expected_errno = EFAULT,
 		.signal_set = {
-			.mask = SIGNO_TO_BIT(SIGSEGV),
+			.mask = SIGNO_TO_BIT(SIGSEGV) | SIGNO_TO_BIT(SIGBUS),
 		},
 	},
 	{

--- a/src/gettimeofday.c
+++ b/src/gettimeofday.c
@@ -345,7 +345,7 @@ static void gettimeofday_abi(struct ctx *ctx)
 
 			args.force_syscall = false;
 			if (gtod_args_should_fault(tv_type, tz_type))
-				signal_set.mask |= SIGNO_TO_BIT(SIGSEGV);
+				signal_set.mask = SIGNO_TO_BIT(SIGSEGV) | SIGNO_TO_BIT(SIGBUS);
 
 			xasprintf(&desc, "gettimeofday(%s, %s) (VDSO)",
 				  gtod_arg_type_str[tv_type],

--- a/src/gettimeofday.c
+++ b/src/gettimeofday.c
@@ -190,14 +190,14 @@ static const char *gtod_arg_type_str[] = {
 static void do_gettimeofday(void *arg, struct syscall_result *res)
 {
 	struct gettimeofday_args *args = arg;
-	int err;
+	int ret;
 
 	syscall_prepare();
 	if (args->force_syscall)
-		err = gettimeofday_syscall_wrapper(args->tv, args->tz);
+		ret = gettimeofday_syscall_wrapper(args->tv, args->tz);
 	else
-		err = gettimeofday_vdso(args->tv, args->tz);
-	record_syscall_result(res, err, errno);
+		ret = DO_VDSO_CALL(gettimeofday_vdso, int, 2, args->tv, args->tz);
+	record_syscall_result(res, ret, errno);
 }
 
 static void *gtod_arg_alloc(enum gtod_arg_type t)


### PR DESCRIPTION
The test doesn't work on MIPS, because:
1. passing UINTPTR_MAX to clock_getres (and some other VDSO functions) would cause the process to be terminated with SIGBUS, not SIGSEGV like some other architectures.
2. gettimeofday_vdso() can return any negative error code, not just -1. It is incorrect to expect it to return -1: